### PR TITLE
Fully specify all fields within `signatures`

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -58,7 +58,7 @@ Parameters:
     -   etc...
 
 *   KEYID is an optional, unauthenticated hint indicating what key was used to
-    sign the message. It **must not** be used for security decisions.
+    sign the message. It **MUST NOT** be used for security decisions.
 
 Functions:
 
@@ -71,7 +71,7 @@ Functions:
     le64(n) := 64-bit little-endian encoding of `n`, where 0 <= n < 2^63
     ```
 
-*   Sign() is an arbitrary digital signature format. Details must be agreed upon
+*   Sign() is an arbitrary digital signature format. Details are agreed upon
     out-of-band by the signer and verifier. This specification places no
     restriction on the signature algorithm or format.
 
@@ -103,13 +103,13 @@ To verify:
     fails.
 
 Either standard or URL-safe base64 encodings are allowed. Signers may use
-either, and verifiers must accept either.
+either, and verifiers **MUST** accept either.
 
 ### Backwards compatible signatures
 
 To convert existing signatures from the current format to the new format,
-`"backwards-compatible-json"` must be added to the payload type URI to indicate
-that the signature is over the raw payload. This allows the signatures to remain
+`"backwards-compatible-json"` is added to the payload type URI to indicate that
+the signature is over the raw payload. This allows the signatures to remain
 valid while avoiding the verifier from having to use [Canonical JSON].
 
 ```json
@@ -127,7 +127,7 @@ Support for this backwards compatibility mode is optional.
 
 To sign:
 
--   BODY **must** be an object type (`{...}`).
+-   BODY **MUST** be an object type (`{...}`).
 -   Serialize BODY as [Canonical JSON]; call this SERIALIZED_BODY.
 -   Sign SERIALIZED_BODY, base64-encode the result, and store it in `sig`.
 -   Optionally, compute a KEYID and store it in `keyid`.
@@ -144,14 +144,14 @@ To verify:
     decoding or the signature verification fails.
 -   Parse SERIALIZED_BODY as a JSON object. Reject if the parsing fails or if
     the result is not a JSON object. In particular, the first byte of
-    SERIALIZED_BODY must be `{`. Verifiers **must not** require SERIALIZED_BODY
+    SERIALIZED_BODY **MUST** be `{`. Verifiers **MUST NOT** require SERIALIZED_BODY
     to be Canonical JSON.
 
 Backwards compatible signatures are not recommended because they lack the
 authenticated payloadType indicator.
 
 This scheme is safe from rollback attacks because the first byte of
-SERIALIZED_BODY must be 0x7b (`{`) in backwards compatibility mode and 0x02 in
+SERIALIZED_BODY is be 0x7b (`{`) in backwards compatibility mode and 0x02 in
 regular mode.
 
 ### Multiple signatures

--- a/specification.md
+++ b/specification.md
@@ -34,11 +34,12 @@ The signature format is a JSON message of the following form:
   "signatures": [{
     "keyid": "<KEYID>",
     "sig": "<Base64(Sign(PAE([UTF8(PAYLOAD_TYPE), SERIALIZED_BODY])))>"
-  }, …]
+  }]
 }
 ```
 
-Empty fields may be omitted. Multiple signatures are allowed.
+Empty fields may be omitted. [Multiple signatures](#multiple-signatures) are
+allowed.
 
 Definitions:
 
@@ -149,6 +150,25 @@ authenticated payloadType indicator.
 This scheme is safe from rollback attacks because the first byte of
 SERIALIZED_BODY must be 0x7b (`{`) in backwards compatibility mode and 0x02 in
 regular mode.
+
+### Multiple signatures
+
+A file may have more than one signature, which is equivalent to separate files
+with individual signatures.
+
+```json
+{
+  "payload": "<Base64(SERIALIZED_BODY)>",
+  "payloadType": "<PAYLOAD_TYPE>",
+  "signatures": [{
+      "keyid": "<KEYID_1>",
+      "sig": "<SIG_1>"
+    }, {
+      "keyid": "<KEYID_2>",
+      "sig": "<SIG_2>"
+  }]
+}
+```
 
 ### Optional changes to wrapper
 
@@ -286,7 +306,7 @@ used by TUF and in-toto has a BODY that is a regular JSON object and a signature
   "signatures": [{
     "keyid": "<KEYID>",
     "sig": "<Hex(Sign(CanonicalJson(BODY)))>"
-  }, …]
+  }]
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -154,7 +154,7 @@ Backwards compatible signatures are not recommended because they lack the
 authenticated payloadType indicator.
 
 This scheme is safe from rollback attacks because the first byte of
-SERIALIZED_BODY is be 0x7b (`{`) in backwards compatibility mode and 0x02 in
+SERIALIZED_BODY is 0x7b (`{`) in backwards compatibility mode and 0x02 in
 regular mode.
 
 ### Multiple signatures

--- a/specification.md
+++ b/specification.md
@@ -57,8 +57,11 @@ Parameters:
     -   https://theupdateframework.com/Root/v1.0.5
     -   etc...
 
-*   KEYID is an optional, unauthenticated hint indicating what key was used to
-    sign the message. It **MUST NOT** be used for security decisions.
+*   KEYID is an optional, unauthenticated hint indicating what key and algorithm
+    was used to sign the message. As with Sign(), details are agreed upon
+    out-of-band by the signer and verifier. It **MUST NOT** be used for security
+    decisions; it may only be used to narrow the selection of possible keys to
+    try.
 
 Functions:
 

--- a/specification.md
+++ b/specification.md
@@ -115,9 +115,9 @@ valid while avoiding the verifier from having to use [Canonical JSON].
   "payload": "<Base64(CanonicalJson(BODY))>",
   "payloadType": "<URI>/backwards-compatible-json",
   "signatures" : [{
-    …,
-    "sig" : "<Base64(Sign(CanonicalJson(BODY)))>"
-  }, …]
+    "keyid": "<KEYID>",
+    "sig": "<Base64(Sign(CanonicalJson(BODY)))>"
+  }]
 }
 ```
 
@@ -128,6 +128,7 @@ To sign:
 -   BODY **must** be an object type (`{...}`).
 -   Serialize BODY as [Canonical JSON]; call this SERIALIZED_BODY.
 -   Sign SERIALIZED_BODY, base64-encode the result, and store it in `sig`.
+-   Optionally, compute a KEYID and store it in `keyid`.
 -   Base64-encode SERIALIZED_BODY and store it in `payload`.
 -   Store `"<URI>/backwards-compatible-json"` in `payloadType`.
 

--- a/specification.md
+++ b/specification.md
@@ -41,7 +41,7 @@ The signature format is a JSON message of the following form:
 Empty fields may be omitted. [Multiple signatures](#multiple-signatures) are
 allowed.
 
-Definitions:
+Parameters:
 
 *   SERIALIZED_BODY is the byte sequence to be signed.
 
@@ -59,6 +59,8 @@ Definitions:
 
 *   KEYID is an optional, unauthenticated hint indicating what key was used to
     sign the message. It **must not** be used for security decisions.
+
+Functions:
 
 *   PAE() is the
     [PASETO Pre-Authentication Encoding](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding),


### PR DESCRIPTION
Closes #4.