### PR TITLE
Remove backwards compatibility mode.

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -247,6 +247,15 @@ Rationales for specific decisions:
     2.  It would incur double base64 encoding overhead for non-JSON payloads.
     3.  It is more complex than PAE.
 
+## Backwards Compatibility
+
+Backwards compatibility with the old format will be handled by the application
+and explained in the corresponding application-specific change proposal, namely
+[ITE-5](https://github.com/in-toto/ITE/pull/13) for in-toto and via the
+principles laid out in
+[TAP-14](https://github.com/theupdateframework/taps/blob/master/tap14.md) for
+TUF.
+
 ## Testing
 
 See [reference implementation](reference_implementation.ipynb). Here is an


### PR DESCRIPTION
This mode allowed for the old signature protocol to be represented in
the new data structure. However, there was no known use case for this.
True backwards compatibility requires supporting both protocol *and*
data structure. Thus, backwards compatibility can be handled at the
application (TUF or in-toto).

Fixes #14.