### PR TITLE
Update date to tag v0.1.0

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3,7 +3,7 @@
 A signature scheme for software supply chain metadata that avoids
 canonicalization
 
-November 25, 2020
+March 03, 2021
 
 Version 0.1.0
 


### PR DESCRIPTION
I was going to put in a version field but it's already there. This PR merely sets the date to today. Once this is merged, I'll tag v0.1.0.