### PR TITLE
payloadType: promote media type; use ITE-5 value

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -31,19 +31,19 @@ KEYID           | string | No       | No
     (JSON, CBOR, etc.) as well as the meaning/schema. To prevent collisions, the
     value SHOULD be either:
 
-    *   [URI](https://tools.ietf.org/html/rfc3986) (recommended)
-        *   Example: `https://in-toto.io/Statement/v1-json`.
-        *   SHOULD resolve to a human-readable description but MAY be
-            unresolvable.
-        *   SHOULD be case-normalized (section 6.2.2.1)
     *   [Media Type](https://www.iana.org/assignments/media-types/), a.k.a. MIME
         type or Content Type
-        *   Example: `application/vnd.in-toto.statement.v1+json`.
+        *   Example: `application/vnd.in-toto+json`.
         *   IMPORTANT: SHOULD NOT be a generic type that only represents
             encoding but not schema. For example, `application/json` is almost
             always WRONG. Instead, invent a media type specific for your
             application in the `application/vnd` namespace.
         *   SHOULD be lowercase.
+    *   [URI](https://tools.ietf.org/html/rfc3986)
+        *   Example: `https://example.com/MyMessage/v1-json`.
+        *   SHOULD resolve to a human-readable description but MAY be
+            unresolvable.
+        *   SHOULD be case-normalized (section 6.2.2.1)
 
 *   KEYID: Optional, unauthenticated hint indicating what key and algorithm was
     used to sign the message. As with Sign(), details are agreed upon


### PR DESCRIPTION
Media Type is the conventional way to indicate the content type of a
payload. Therefore, we no longer suggest that URL is preferred over
Media Type. This puts signing-spec in line with other envelopes, such as
JWS.

Also, use in-toto media type from
[ITE-5](https://github.com/in-toto/ITE/pull/17) and switch the URL
example to a dummy value.