### PR TITLE
Allow signature-less envelopes.

### DIFF
--- a/envelope.md
+++ b/envelope.md
@@ -55,6 +55,20 @@ envelopes with individual signatures.
 }
 ```
 
+### No signatures
+
+An envelope MAY have zero signatures to indicate unsigned data. For example,
+[SLSA 1](https://github.com/slsa-framework/slsa) does not require authenticated
+[in-toto provenance](https://github.com/in-toto/attestation/blob/main/spec/predicates/provenance.md),
+in which case an envelope with zero signatures may be useful.
+
+```json
+{
+  "payload": "<Base64(SERIALIZED_BODY)>",
+  "payloadType": "<PAYLOAD_TYPE>"
+}
+```
+
 ## Other data structures
 
 The standard envelope is JSON message with an explicit `payloadType`.

--- a/envelope.proto
+++ b/envelope.proto
@@ -19,7 +19,7 @@ message Envelope {
   //     le64(n) := 64-bit little-endian encoding of integer `n`, 0 <= n < 2^63
   //     len(s) := number of octets in byte sequence `s`
   //     utf8(s) := UTF-8 encoding of unicode string `s`
-  // REQUIRED (length >= 1).
+  // OPTIONAL.
   repeated Signature signatures = 3;
 }
 


### PR DESCRIPTION
This supports cases where the consumer is not expected to verify anything, so the producer doesn't need to use a dummy signature.

**Note to reviewers:** Does this leave too much room for people to shoot themselves in the foot? On the one hand, this seems like it might encourage [`alg=none`](https://www.howmanydayssinceajwtalgnonevuln.com/)-type vulnerabilities. On the other, we have an actual use case for unauthenticated in-toto attestations (SLSA 1); publishing the raw payload also doesn't seem super desirable.

@dlorenc @msuozzo @loosebazooka FYI